### PR TITLE
avoid bindgen-generated Debug impl of dtls_hello_verify_t

### DIFF
--- a/tinydtls-sys/build.rs
+++ b/tinydtls-sys/build.rs
@@ -112,6 +112,8 @@ fn main() {
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .default_enum_style(EnumVariation::Rust { non_exhaustive: true })
         .rustfmt_bindings(false)
+        // Some types cannot have `Debug` as they are packed and have non-Copy fields.
+        .no_debug("dtls_hello_verify_t")
         // Declarations that should be part of the bindings.
         .allowlist_function("dtls_.*")
         .allowlist_type("dtls_.*")

--- a/tinydtls-sys/src/lib.rs
+++ b/tinydtls-sys/src/lib.rs
@@ -12,6 +12,8 @@
 #![allow(non_upper_case_globals)]
 #![allow(deref_nullptr)]
 
+use std::fmt;
+
 use libc::{sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, socklen_t};
 
 #[cfg(target_family = "windows")]
@@ -30,6 +32,19 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 #[inline]
 pub unsafe fn dtls_set_handler(ctx: *mut dtls_context_t, h: *mut dtls_handler_t) {
     (*ctx).h = h;
+}
+
+// For backwards-compatibility, we add a Debug implementation of dtls_hello_verify_t.
+// (Automatic derive stopped working with https://github.com/rust-lang/rust/pull/104429.)
+impl fmt::Debug for dtls_hello_verify_t {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { version, cookie_length, cookie } = self;
+        fmt.debug_struct("dtls_hello_verify_t")
+            .field("version", version)
+            .field("cookie_length", cookie_length)
+            .field("cookie", cookie)
+            .finish()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This crate is one of the few that was identified as part of https://github.com/rust-lang/rust/pull/104429 to have a packed struct with a built-in derive and a non-Copy field where furthermore the packed does not actually change the layout at all: `dtls_hello_verify_t`. That struct is declared in bindgen-generated code. Usually bindgen requires a `no_debug` for packed structs precisely because `derive(Debug)` will fail otherwise, but this crate happened to exploit an essentially accidental exception to that rule -- an exception that might stop working in the future because it is in the way of enabling a lot of other `derive` of packed types. This PR avoids the built-in derive and instead implements `Debug` by hand, which should keep working.