### PR TITLE
Bump tinydtls and crate version, fix unnecessary rebuilds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tinydtls-sys/src/tinydtls"]
 	path = tinydtls-sys/src/tinydtls
 	url = https://github.com/eclipse/tinydtls.git
-	branch = develop
+	branch = main

--- a/tinydtls-sys/Cargo.toml
+++ b/tinydtls-sys/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "tinydtls-sys"
 description = "Raw bindings to the TinyDTLS library."
-version = "0.1.1+tinydtls-c7c3ca8"
+version = "0.1.2+tinydtls-c84e36f"
 edition = "2021"
 links = "tinydtls"
 # For tinydtls, both licenses can be applied, see https://www.eclipse.org/legal/eplfaq.php#DUALLIC


### PR DESCRIPTION
This PR updates tinydtls to the latest upstream version and bumps the crate version number to 0.1.2. Additionally, it fixes a small issue that caused tinydtls-sys to be rebuilt on every cargo run. 