### PR TITLE
bump tinydtls to 9d6cf54, update bindgen, bump crate version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@
 members = [
     "tinydtls-sys",
 ]
+resolver = "2"

--- a/tinydtls-sys/Cargo.toml
+++ b/tinydtls-sys/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "tinydtls-sys"
 description = "Raw bindings to the TinyDTLS library."
-version = "0.1.2+tinydtls-c84e36f"
+version = "0.2.0+tinydtls-9d6cf54"
 edition = "2021"
 links = "tinydtls"
 # For tinydtls, both licenses can be applied, see https://www.eclipse.org/legal/eplfaq.php#DUALLIC
@@ -18,6 +18,7 @@ authors = ["Hugo Hakim Damer <hdamer@uni-bremen.de>"]
 categories = ["external-ffi-bindings", "network-programming", "cryptography", "embedded"]
 keywords = ["tinydtls", "sys", "dtls", "crypto"]
 exclude = ['/src/tinydtls/share/', '/src/tinydtls/include/', '/src/tinydtls/configure.prev']
+resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
@@ -39,6 +40,6 @@ libc = "^0.2.112"
 lazy_static = "^1.4"
 
 [build-dependencies]
-bindgen = "^0.59.2"
+bindgen = "^0.69.4"
 autotools = "^0.2.3"
 fs_extra = "^1.2"

--- a/tinydtls-sys/build.rs
+++ b/tinydtls-sys/build.rs
@@ -113,7 +113,7 @@ fn main() {
     bindgen_builder = bindgen_builder
         .header("src/wrapper.h")
         .default_enum_style(EnumVariation::Rust { non_exhaustive: true })
-        .rustfmt_bindings(false)
+        .formatter(bindgen::Formatter::None)
         // Some types cannot have `Debug` as they are packed and have non-Copy fields.
         .no_debug("dtls_hello_verify_t")
         // Declarations that should be part of the bindings.
@@ -158,7 +158,7 @@ fn main() {
         // the included headers seem to come from our built version.
         // Should be fine though, as we already printed `cargo:rerun-if-changed=src/tinydtls/` at the
         // start of the file.
-        bindgen_builder = bindgen_builder.parse_callbacks(Box::new(bindgen::CargoCallbacks));
+        bindgen_builder = bindgen_builder.parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
     }
 
     // Run binding generation and write the output to a file.

--- a/tinydtls-sys/src/lib.rs
+++ b/tinydtls-sys/src/lib.rs
@@ -402,6 +402,7 @@ mod tests {
             get_psk_info: Some(echo_get_psk_info),
             get_ecdsa_key: None,
             verify_ecdsa_key: None,
+            get_user_parameters: None,
         };
 
         // SAFETY: Supplied pointer is valid, dtls_new_context does not do anything with it except
@@ -433,8 +434,6 @@ mod tests {
         // this pointer should be valid up until here.
         unsafe {
             dtls_free_context(server_context);
-            // To ensure that we don't use the context pointer sometime later (in case the tests are extended later on), we drop the pointer.
-            std::mem::drop(server_context);
         }
     }
 
@@ -463,6 +462,7 @@ mod tests {
             get_psk_info: Some(echo_get_psk_info),
             get_ecdsa_key: None,
             verify_ecdsa_key: None,
+            get_user_parameters: None,
         };
 
         let client_socket = UdpSocket::bind("localhost:0").expect("Could not bind UDP socket");
@@ -512,8 +512,6 @@ mod tests {
         // this pointer should be valid up until here.
         unsafe {
             dtls_free_context(client_context);
-            // To ensure that we don't use the context pointer sometime later (in case the tests are extended later on), we drop the pointer.
-            std::mem::drop(client_context);
         }
         server_thread.join().unwrap();
     }


### PR DESCRIPTION
bindgen 0.59.X depended on a crate with a cargo audit warning, updating it to fix that.

Also made some minor changes to build script and tests to accomodate for bindgen and tinydtls changes.

Crate version has to be updated to 0.2.0 because tinydtls added an additional field to `dtls_handler_t`, which is a breaking change (unsure if there are more breaking changes, but that one was immediately noticable because the tests wouldn't compile anymore).